### PR TITLE
Add missing `id` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
     steps:
       - name: Send message to Slack API
         uses: archive/github-actions-slack@v1.0.3
+        id: notify
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: test
@@ -89,6 +90,7 @@ jobs:
     steps:
       - name: Send message to Slack API
         uses: archive/github-actions-slack@v1.0.3
+        id: notify
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: test


### PR DESCRIPTION
Thanks for sharing your excellent GitHub Action! 👍 

Today I tried to use this, and found that the README has a room to improve.
To refer the output of specific step, the target step should have an [`id` option](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsid), so I suggest you to add it like this.

