### PR TITLE
Evaluating Windows support

### DIFF
--- a/.github/workflows/slack-notification-with-optional-parameters.yml
+++ b/.github/workflows/slack-notification-with-optional-parameters.yml
@@ -19,4 +19,4 @@ jobs:
           slack-optional-as_user: false
 
       - name: Result from "Send Slack Message"
-        run: echo "${{ steps.send-message.outputs.slack-result }}"
+        run: echo '${{ steps.send-message.outputs.slack-result }}'

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -4,7 +4,7 @@ on: [push, issues]
 
 jobs:
   slack-notification:
-    runs-on: ubuntu-20.04
+    runs-on: windows-2019
     name: Test 2 (Sends message on Push and Issue)
 
     steps:

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -17,4 +17,4 @@ jobs:
           slack-text: Test 2 - 🤓 With Event name "${{ github.event_name }}" and Repo "${{ github.repository }}" [at mater]
 
       - name: Result from "Send Slack Message"
-        run: echo "${{ steps.send-message.outputs.slack-result }}"
+        run: echo '${{ steps.send-message.outputs.slack-result }}'

--- a/.github/workflows/slack-reaction.yml
+++ b/.github/workflows/slack-reaction.yml
@@ -19,10 +19,10 @@ jobs:
           slack-text: Test 3 - Message to send a react to [at master]
 
       - name: Send Slack Message Result
-        run: echo "Data - ${{ steps.send-message.outputs.slack-result }}"
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'
 
       - name: Some step in between
-        run: echo "..."
+        run: echo '...'
 
       - name: Send Slack Reaction To Message
         uses: archive/github-actions-slack@master
@@ -34,4 +34,4 @@ jobs:
           slack-message-timestamp: ${{ fromJson(steps.send-message.outputs.slack-result).response.message.ts }}
 
       - name: Send Slack Reaction To Message Result
-        run: echo "Data - ${{ steps.send-message.outputs.slack-result }}"
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'

--- a/.github/workflows/slack-thread.yml
+++ b/.github/workflows/slack-thread.yml
@@ -19,10 +19,10 @@ jobs:
           slack-text: Test 4 - Message to send thread to [at master]
 
       - name: Send "Slack Message" Result
-        run: echo "Data - ${{ steps.send-message.outputs.slack-result }}"
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'
 
       - name: Some step in between
-        run: echo "..."
+        run: echo '...''
 
       - name: Send Thread Message
         uses: archive/github-actions-slack@master
@@ -35,4 +35,4 @@ jobs:
           #slack-optional-reply_broadcast: true # To broadcast thread reply in channel
 
       - name: Send "Send Thread Message" Result
-        run: echo "Data - ${{ steps.send-message.outputs.slack-result }}"
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'

--- a/.github/workflows/slack-thread.yml
+++ b/.github/workflows/slack-thread.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'
 
       - name: Some step in between
-        run: echo '...''
+        run: echo '...'
 
       - name: Send Thread Message
         uses: archive/github-actions-slack@master

--- a/.github/workflows/slack-update-message.yml
+++ b/.github/workflows/slack-update-message.yml
@@ -19,10 +19,10 @@ jobs:
           slack-text: Test 5 - Message to update [at master]
 
       - name: Send Slack Message Result
-        run: echo "Data - ${{ steps.send-message.outputs.slack-result }}"
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}''
 
       - name: Some step in between
-        run: echo "..."
+        run: echo '...'
 
       - name: Send Slack Reaction To Message
         uses: archive/github-actions-slack@master
@@ -34,4 +34,4 @@ jobs:
           slack-update-message-ts: ${{ fromJson(steps.send-message.outputs.slack-result).response.message.ts }}
 
       - name: Send Slack Reaction To Message Result
-        run: echo "Data - ${{ steps.send-message.outputs.slack-result }}"
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'

--- a/.github/workflows/slack-update-message.yml
+++ b/.github/workflows/slack-update-message.yml
@@ -19,7 +19,7 @@ jobs:
           slack-text: Test 5 - Message to update [at master]
 
       - name: Send Slack Message Result
-        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}''
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'
 
       - name: Some step in between
         run: echo '...'

--- a/dist/index.js
+++ b/dist/index.js
@@ -752,7 +752,10 @@ const addReaction = async () => {
     const messageTimestamp = context.getRequired("slack-message-timestamp");
 
     const payload = buildMessage(channelId, emojiName, messageTimestamp);
+
+    context.debugExtra("Add Reaction PAYLOAD", payload);
     const result = await apiAddReaction(token, payload);
+    context.debugExtra("Add Reaction PAYLOAD", result);
 
     const resultAsJson = jsonPretty(result);
     context.setOutput("slack-result", resultAsJson);

--- a/src/reaction/index.js
+++ b/src/reaction/index.js
@@ -12,7 +12,10 @@ const addReaction = async () => {
     const messageTimestamp = context.getRequired("slack-message-timestamp");
 
     const payload = buildMessage(channelId, emojiName, messageTimestamp);
+
+    context.debugExtra("Add Reaction PAYLOAD", payload);
     const result = await apiAddReaction(token, payload);
+    context.debugExtra("Add Reaction PAYLOAD", result);
 
     const resultAsJson = jsonPretty(result);
     context.setOutput("slack-result", resultAsJson);


### PR DESCRIPTION
#23

In the yaml example files, `echo` is used to print the result from the previous step. On the `echo` line, double quotes was used to print the message. This worked on linux, but not on windows. 

This is because `echo` is an alias for `Write-Output` in PowerShell, and in PowerShell the json printed broke the execution: 
![image](https://user-images.githubusercontent.com/351045/121820530-92cb7c00-cc93-11eb-8e00-f14d414778da.png)

The send message worked, but the github action failed on the post step. If we change the " to ' everything works as expected. 