### PR TITLE
The reply_broadcast message subtype is no longer served

### DIFF
--- a/.github/workflows/slack-thread-with-broadcast.yml
+++ b/.github/workflows/slack-thread-with-broadcast.yml
@@ -1,0 +1,38 @@
+name: slack-thread-with-broadcast
+
+on: [push, issues]
+
+jobs:
+  slack-thread-with-broadcast:
+    runs-on: ubuntu-20.04
+    name: Test 6 (Sends message on Push and Issue)
+
+    steps:
+      - name: Send Slack Message
+        uses: archive/github-actions-slack@master
+        id: send-message
+
+        with:
+          slack-function: send-message
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: CPPUV5KU0
+          slack-text: Test 6 - Message to send thread to [at master]
+
+      - name: Send "Slack Message" Result
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'
+
+      - name: Some step in between
+        run: echo '...'
+
+      - name: Send Thread Message
+        uses: archive/github-actions-slack@master
+        with:
+          slack-function: send-message
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: ${{ fromJson(steps.send-message.outputs.slack-result).response.channel }}
+          slack-text: Test 6.1 - Reply in thread, with broadcast
+          slack-optional-thread_ts: ${{ fromJson(steps.send-message.outputs.slack-result).response.message.ts }}
+          slack-optional-reply_broadcast: true
+
+      - name: Send "Send Thread Message" Result
+        run: echo 'Data - ${{ steps.send-message.outputs.slack-result }}'


### PR DESCRIPTION
The reply_broadcast message subtype is no longer served. It has been replaced with thread_broadcast (https://api.slack.com/events/message/reply_broadcast)

Does this affect postMessage? 