### PR TITLE
Make update-message escapping more consistent with send-message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -828,17 +828,29 @@ module.exports = { addReaction };
 /***/ 51:
 /***/ ((module) => {
 
-const buildUpdateMessage = (channelId = "", text = "", ts = "") => {
+const buildMessage = (channel = "", text = "", ts="", optional={}) => {
   const message = {
-    channel: channelId,
-    text: text,
-    ts: ts,
+    channel,
+    text,
+    ts
   };
+
+  message.text = restoreEscapedNewLine(message.text);
+  message.text = restoreEscapedTab(message.text);
+
+  Object.keys(optional).forEach((name) => {
+    message[name] = optional[name];
+  });
 
   return message;
 };
 
-module.exports = buildUpdateMessage;
+const restoreEscapedNewLine = (text) =>
+  text.replace(/\\r\\n/g, "\n").replace(/\\n/g, "\n");
+
+const restoreEscapedTab = (text) => text.replace(/\\t/g, "\t");
+
+module.exports = buildMessage;
 
 
 /***/ }),

--- a/src/update-message/build-update-message.js
+++ b/src/update-message/build-update-message.js
@@ -1,11 +1,23 @@
-const buildUpdateMessage = (channelId = "", text = "", ts = "") => {
+const buildMessage = (channel = "", text = "", ts="", optional={}) => {
   const message = {
-    channel: channelId,
-    text: text,
-    ts: ts,
+    channel,
+    text,
+    ts
   };
+
+  message.text = restoreEscapedNewLine(message.text);
+  message.text = restoreEscapedTab(message.text);
+
+  Object.keys(optional).forEach((name) => {
+    message[name] = optional[name];
+  });
 
   return message;
 };
 
-module.exports = buildUpdateMessage;
+const restoreEscapedNewLine = (text) =>
+  text.replace(/\\r\\n/g, "\n").replace(/\\n/g, "\n");
+
+const restoreEscapedTab = (text) => text.replace(/\\t/g, "\t");
+
+module.exports = buildMessage;


### PR DESCRIPTION
I had some trouble with my update-messages not turning out like my send-message.

I made the escaping logic more consistent in a fork and am using that for now. This PR contains those changes. I didn't make any attempt to be DRY if that is a concern. I just copied and pasted the logic. Opening this up for reference and hoping some version will be incorporated upstream.

Thanks.

PS: I'd rather be using blocks, and I'm excited about that WIP PR to be able to update blocks. 