### PR TITLE
Update message with blocks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,10 @@ inputs:
     required: true
   slack-text:
     description: "Text"
-    required: true
+    required: false
+  slack-blocks:
+    description: "Blocks"
+    required: false
   slack-optional-as_user:
     description: "https://api.slack.com/methods/chat.postMessage#arg_as_user"
     required: false
@@ -66,6 +69,9 @@ inputs:
     required: false
   slack-update-message-text:
     description: https://api.slack.com/methods/chat.update#text
+    required: false
+  slack-update-message-blocks:
+    description: https://api.slack.com/methods/chat.update#blocks
     required: false
 
 outputs:

--- a/src/message/build-message.js
+++ b/src/message/build-message.js
@@ -3,10 +3,11 @@ const {
   restoreEscapedTab,
 } = require("../util/escaper.js");
 
-const buildMessage = (channel = "", text = "", optional = {}) => {
+const buildMessage = (channel = "", text = "", blocks = "", optional = {}) => {
   const message = {
     channel,
     text,
+    blocks,
   };
 
   message.text = restoreEscapedNewLine(message.text);

--- a/src/message/build-message.test.js
+++ b/src/message/build-message.test.js
@@ -2,22 +2,24 @@ describe("build message", () => {
   test("with channel and text parameters", () => {
     const buildMessage = require("./build-message");
 
-    const message = buildMessage("channel", "text");
+    const message = buildMessage("channel", "text", "blocks");
 
     expect(message).toEqual({
       channel: "channel",
       text: "text",
+      blocks: "blocks",
     });
   });
 
   test("with optional parameters", () => {
     const buildMessage = require("./build-message");
 
-    const message = buildMessage("channel", "text", { key: "value" });
+    const message = buildMessage("channel", "text", "blocks", { key: "value" });
 
     expect(message).toEqual({
       channel: "channel",
       text: "text",
+      blocks: "blocks",
       key: "value",
     });
   });

--- a/src/message/index.js
+++ b/src/message/index.js
@@ -9,13 +9,14 @@ const postMessage = async () => {
   try {
     const token = context.getRequired("slack-bot-user-oauth-access-token");
     const channels = context.getRequired("slack-channel");
-    const text = context.getRequired("slack-text");
+    const text = context.getOptional("slack-text");
+    const blocks = context.getOptional("slack-blocks");
 
     const results = [];
     for (let channel of channels.split(",")) {
       channel = channel.trim();
 
-      const payload = buildMessage(channel, text, optional());
+      const payload = buildMessage(channel, text, blocks, optional());
 
       context.debug("Post Message PAYLOAD", payload);
       const result = await apiPostMessage(token, payload);

--- a/src/update-message/build-update-message.js
+++ b/src/update-message/build-update-message.js
@@ -3,11 +3,12 @@ const {
   restoreEscapedTab,
 } = require("../util/escaper.js");
 
-const buildMessage = (channel = "", text = "", ts = "", optional = {}) => {
+const buildMessage = (channel = "", text = "", blocks = "", ts = "", optional = {}) => {
   const message = {
     channel,
     text,
     ts,
+    blocks,
   };
 
   message.text = restoreEscapedNewLine(message.text);

--- a/src/update-message/index.js
+++ b/src/update-message/index.js
@@ -8,10 +8,11 @@ const updateMessage = async () => {
   try {
     const token = context.getRequired("slack-bot-user-oauth-access-token");
     const channelId = context.getRequired("slack-channel");
-    const text = context.getRequired("slack-update-message-text");
     const ts = context.getRequired("slack-update-message-ts");
+    const text = context.getOptional("slack-update-message-text");
+    const blocks = context.getOptional("slack-update-message-blocks");
 
-    const payload = buildUpdateMessage(channelId, text, ts, optional());
+    const payload = buildUpdateMessage(channelId, text, blocks, ts, optional());
 
     context.debugExtra("Update Message PAYLOAD", payload);
     const result = await apiUpdateMessage(token, payload);

--- a/src/update-message/index.js
+++ b/src/update-message/index.js
@@ -11,7 +11,7 @@ const updateMessage = async () => {
     const text = context.getRequired("slack-update-message-text");
     const ts = context.getRequired("slack-update-message-ts");
 
-    const payload = buildUpdateMessage(channelId, text, ts);
+    const payload = buildUpdateMessage(channelId, text, ts, optional());
 
     context.debugExtra("Update Message PAYLOAD", payload);
     const result = await apiUpdateMessage(token, payload);
@@ -23,6 +23,21 @@ const updateMessage = async () => {
     context.debug(error);
     context.setFailed(jsonPretty(error));
   }
+};
+
+const optional = () => {
+  let opt = {};
+
+  const env = context.getEnv();
+  Object.keys(env)
+    .filter((key) => !!env[key])
+    .filter((key) => key.toUpperCase().startsWith("INPUT_SLACK-OPTIONAL-"))
+    .forEach((key) => {
+      const slackKey = key.replace("INPUT_SLACK-OPTIONAL-", "").toLowerCase();
+      opt[slackKey] = env[key];
+    });
+
+  return opt;
 };
 
 module.exports = { updateMessage };


### PR DESCRIPTION
I wanted to be able to update slack messages using blocks, which didn't seem to work because the `blocks` argument wasn't passed through. In this PR i made the `text` argument optional and added the optional `blocks` argument similar to the slack api. 

Together with https://github.com/archive/github-actions-slack/pull/42, this replaces https://github.com/archive/github-actions-slack/pull/38

Let me know what you think