### PR TITLE
Remove "as_user" since it has be deprecated by Slack for new Apps

### DIFF
--- a/.github/workflows/1-slack-notification-with-optional-parameters.yml
+++ b/.github/workflows/1-slack-notification-with-optional-parameters.yml
@@ -17,7 +17,6 @@ jobs:
           slack-channel: C02HEBQP46T
           slack-text: "Test 1 - :fire:"
           slack-optional-icon_emoji: ":fire:"
-          slack-optional-as_user: false
 
       - name: Result from "Send Slack Message"
         run: echo '${{ steps.send-message.outputs.slack-result }}'

--- a/.github/workflows/10-slack-fake-build-updates.yml
+++ b/.github/workflows/10-slack-fake-build-updates.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   slack-action:
     #if: ${{ false }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-lates
     name: Test 10 [ubuntu-20.04]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ jobs:
           slack-channel: CPPUV5KU0 #USE CHANNEL ID, NOT CHANNEL NAME, SINCE ID IS USED IN NEW SLACK API's
           slack-text: Hello! Something is burning! Or not...
           slack-optional-icon_emoji: ":fire:"
-          slack-optional-as_user: false
       - name: Result from "Send Message"
         run: echo "The result was ${{ steps.notify.outputs.slack-result }}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,9 @@ inputs:
   slack-blocks:
     description: "Blocks"
     required: false
-  slack-optional-as_user:
-    description: "https://api.slack.com/methods/chat.postMessage#arg_as_user"
-    required: false
+  #slack-optional-as_user: - THIS HAS BEEN DEPRECATED BY SLACK - https://twitter.com/SlackAPI/status/1288171767887024130
+  #  description: "https://api.slack.com/methods/chat.postMessage#arg_as_user"
+  #  required: false
   slack-optional-attachments:
     description: "https://api.slack.com/methods/chat.postMessage#arg_attachments"
     required: false

--- a/integration-test/end-to-end.js
+++ b/integration-test/end-to-end.js
@@ -11,7 +11,6 @@ const buildUpdateMessage = require("../src/update-message/build-update-message")
 
 const testSendMessage = async (channel, token, text, optional = {}) => {
   const message = buildMessage(channel, text, null, {
-    as_user: false,
     icon_emoji: ":fire:",
     ...optional,
   });
@@ -23,7 +22,6 @@ const testSendMessage = async (channel, token, text, optional = {}) => {
 
 const testSendReaction = async (channel, token) => {
   const message = buildMessage(channel, "Test 2 - testSendReaction 🤓", null, {
-    as_user: false,
     icon_emoji: ":fire:",
   });
   const messageToReactTo = await apiPostMessage(token, message);


### PR DESCRIPTION
## Why & What
Slack has deprecated `as_user`: https://twitter.com/SlackAPI/status/1288171767887024130, so it's time to remove it from this action. 