### PR TITLE
Move from Node v16 to Node v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,5 +78,5 @@ outputs:
   slack-result:
     description: "The result from the post to slack"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Node 16 has reached its end of life

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/